### PR TITLE
Add book detail page

### DIFF
--- a/web/src/main/java/com/bookstore/web/clients/IBooksClient.java
+++ b/web/src/main/java/com/bookstore/web/clients/IBooksClient.java
@@ -3,6 +3,7 @@ package com.bookstore.web.clients;
 import com.bookstore.web.external.Book;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
 
@@ -10,4 +11,7 @@ import java.util.List;
 public interface IBooksClient {
     @GetMapping
     List<Book> getBooks();
+
+    @GetMapping("/{id}")
+    Book getBookById(@PathVariable("id") Long id);
 }

--- a/web/src/main/java/com/bookstore/web/controllers/BooksPageController.java
+++ b/web/src/main/java/com/bookstore/web/controllers/BooksPageController.java
@@ -5,6 +5,7 @@ import com.bookstore.web.external.Book;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
@@ -23,5 +24,13 @@ public class BooksPageController {
         List<Book> books = booksClient.getBooks();
         model.addAttribute("books", books);
         return "books";
+
+    }
+
+    @GetMapping("/books/{id}")
+    public String getBookDetail(@PathVariable("id") Long id, Model model) {
+        Book book = booksClient.getBookById(id);
+        model.addAttribute("book", book);
+        return "book-detail";
     }
 }

--- a/web/src/main/resources/static/book-detail.css
+++ b/web/src/main/resources/static/book-detail.css
@@ -1,0 +1,63 @@
+.book-detail {
+    max-width: 800px;
+    margin: 2rem auto;
+    display: flex;
+    gap: 2rem;
+    padding: 1rem;
+}
+
+.book-detail img {
+    max-width: 300px;
+    border-radius: 8px;
+}
+
+.book-info h1 {
+    margin: 0 0 0.5rem;
+}
+
+.author {
+    color: #666;
+    font-size: 1.1rem;
+}
+
+.author a {
+    color: #2a7ae2;
+    text-decoration: none;
+}
+
+.genre {
+    color: #888;
+    font-style: italic;
+}
+
+.description {
+    margin-top: 1rem;
+    line-height: 1.6;
+}
+
+.pricing {
+    margin-top: 1.5rem;
+}
+
+.price {
+    font-size: 1.4rem;
+    font-weight: bold;
+    color: #2a7ae2;
+}
+
+.stock {
+    color: #2e8b57;
+    margin-top: 0.5rem;
+}
+
+.out-of-stock {
+    color: #cc3333;
+    margin-top: 0.5rem;
+}
+
+.back-link {
+    display: inline-block;
+    margin-top: 1.5rem;
+    color: #2a7ae2;
+    text-decoration: none;
+}

--- a/web/src/main/resources/templates/book-detail.html
+++ b/web/src/main/resources/templates/book-detail.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/public-layout.html}">
+<head>
+    <title th:text="${book.title}">Book Title</title>
+    <link rel="stylesheet" th:href="@{/css/book-detail.css}"/>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="book-detail">
+        <img th:if="${book.coverImageUrl != null}"
+             th:src="${book.coverImageUrl}"
+             alt="Book cover"/>
+
+        <div class="book-info">
+            <h1 th:text="${book.title}">Title</h1>
+            <p class="author">
+                by <a th:href="@{'/authors/' + ${book.authorId}}"
+                      th:text="${book.authorName}">Author Name</a>
+            </p>
+            <p class="genre" th:text="${book.genre}">Genre</p>
+            <p class="description" th:text="${book.description}">
+                Description text
+            </p>
+
+            <div class="pricing">
+                        <span class="price"
+                              th:text="'$' + ${book.price}">$0.00</span>
+            </div>
+
+            <p class="stock"
+               th:if="${book.quantity != null and book.quantity > 0}"
+               th:text="${book.quantity} + ' in stock'">In stock</p>
+            <p class="out-of-stock"
+               th:if="${book.quantity == null or book.quantity == 0}">
+                Out of stock
+            </p>
+
+            <a th:href="@{/}" class="back-link">Back to all books</a>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/web/src/main/resources/templates/books.html
+++ b/web/src/main/resources/templates/books.html
@@ -11,7 +11,7 @@
             <h1>Books</h1>
             <div>
                 <th:block th:each="book : ${books}">
-                    <div th:text="${book.title}"></div>
+                    <a th:href="@{'/books/' + ${book.id}}" th:text="${book.title}"></a>
                 </th:block>
             </div>
         </div>


### PR DESCRIPTION
#### Description
Added the book detail page at `/books/:id`. Clicking a book title on the listing page now takes you to a detail view showing the cover image, title, author, genre, description, price, and stock quantity.

#### Notes
- The author name links to `/authors/:id` which hasn't been built yet
- Updated `books.html` to make book titles clickable links

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation update
- [ ]  Refactor
- [ ]  Hotfix
- [ ]  Security patch
- [ ]  UI/UX improvement
- [ ]  Dependency update
- [ ]  CI/CD update

---

#### **Screenshot or link to relevant section of the app if applicable**



<img width="1723" height="1153" alt="Screenshot 2026-03-15 220633" src="https://github.com/user-attachments/assets/2e8985ca-00b9-4f4a-9506-e1bcafd53d61" />


---

#### Checklist

- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  `main` has been merged into this branch
- [ x ]  The project builds and runs locally
- [ x ]  This change has been tested in development
- [ x ]  This change generates no new CodeQL alerts