### PR TITLE
Author detail page

### DIFF
--- a/web/src/main/java/com/bookstore/web/clients/IAuthorsClient.java
+++ b/web/src/main/java/com/bookstore/web/clients/IAuthorsClient.java
@@ -1,0 +1,16 @@
+package com.bookstore.web.clients;
+
+import com.bookstore.web.external.Author;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(
+        name = "AUTHORS-PUBLIC-SERVICE",
+        url = "http://localhost:5000/api/authors"
+)
+public interface IAuthorsClient {
+
+    @GetMapping("/{id}")
+    Author getAuthorById(@PathVariable("id") Long id);
+}

--- a/web/src/main/java/com/bookstore/web/clients/IBooksClient.java
+++ b/web/src/main/java/com/bookstore/web/clients/IBooksClient.java
@@ -3,6 +3,7 @@ package com.bookstore.web.clients;
 import com.bookstore.web.external.Book;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
 
@@ -10,4 +11,7 @@ import java.util.List;
 public interface IBooksClient {
     @GetMapping
     List<Book> getBooks();
+
+    @GetMapping("/{id}")
+    Book getBookById(@PathVariable("id") Long id);
 }

--- a/web/src/main/java/com/bookstore/web/controllers/AuthorsPageController.java
+++ b/web/src/main/java/com/bookstore/web/controllers/AuthorsPageController.java
@@ -1,0 +1,25 @@
+package com.bookstore.web.controllers;
+
+import com.bookstore.web.clients.IAuthorsClient;
+import com.bookstore.web.external.Author;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+public class AuthorsPageController {
+
+    IAuthorsClient authorsClient;
+
+    public AuthorsPageController(IAuthorsClient authorsClient) {
+        this.authorsClient = authorsClient;
+    }
+
+    @GetMapping("/authors/{id}")
+    public String getAuthorDetail(@PathVariable("id") Long id, Model model) {
+        Author author = authorsClient.getAuthorById(id);
+        model.addAttribute("author", author);
+        return "author-detail";
+    }
+}

--- a/web/src/main/java/com/bookstore/web/controllers/BooksPageController.java
+++ b/web/src/main/java/com/bookstore/web/controllers/BooksPageController.java
@@ -5,6 +5,7 @@ import com.bookstore.web.external.Book;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
@@ -23,5 +24,13 @@ public class BooksPageController {
         List<Book> books = booksClient.getBooks();
         model.addAttribute("books", books);
         return "books";
+
+    }
+
+    @GetMapping("/books/{id}")
+    public String getBookDetail(@PathVariable("id") Long id, Model model) {
+        Book book = booksClient.getBookById(id);
+        model.addAttribute("book", book);
+        return "book-detail";
     }
 }

--- a/web/src/main/resources/static/author-detail.css
+++ b/web/src/main/resources/static/author-detail.css
@@ -1,0 +1,58 @@
+.author-detail {
+    max-width: 800px;
+    margin: 2rem auto;
+    display: flex;
+    gap: 2rem;
+    padding: 1rem;
+}
+
+.author-detail img {
+    max-width: 250px;
+    border-radius: 8px;
+}
+
+.author-info h1 {
+    margin: 0 0 0.5rem;
+}
+
+.bio {
+    margin-top: 1rem;
+    line-height: 1.6;
+    color: #444;
+}
+
+.author-books {
+    margin-top: 2rem;
+}
+
+.author-books h2 {
+    margin-bottom: 0.5rem;
+    font-size: 1.3rem;
+}
+
+.author-books ul {
+    list-style: none;
+    padding: 0;
+}
+
+.author-books li {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #eee;
+}
+
+.author-books a {
+    color: #2a7ae2;
+    text-decoration: none;
+    font-size: 1.05rem;
+}
+
+.book-price {
+    color: #666;
+}
+
+.back-link {
+    display: inline-block;
+    margin-top: 1.5rem;
+    color: #2a7ae2;
+    text-decoration: none;
+}

--- a/web/src/main/resources/static/book-detail.css
+++ b/web/src/main/resources/static/book-detail.css
@@ -1,0 +1,63 @@
+.book-detail {
+    max-width: 800px;
+    margin: 2rem auto;
+    display: flex;
+    gap: 2rem;
+    padding: 1rem;
+}
+
+.book-detail img {
+    max-width: 300px;
+    border-radius: 8px;
+}
+
+.book-info h1 {
+    margin: 0 0 0.5rem;
+}
+
+.author {
+    color: #666;
+    font-size: 1.1rem;
+}
+
+.author a {
+    color: #2a7ae2;
+    text-decoration: none;
+}
+
+.genre {
+    color: #888;
+    font-style: italic;
+}
+
+.description {
+    margin-top: 1rem;
+    line-height: 1.6;
+}
+
+.pricing {
+    margin-top: 1.5rem;
+}
+
+.price {
+    font-size: 1.4rem;
+    font-weight: bold;
+    color: #2a7ae2;
+}
+
+.stock {
+    color: #2e8b57;
+    margin-top: 0.5rem;
+}
+
+.out-of-stock {
+    color: #cc3333;
+    margin-top: 0.5rem;
+}
+
+.back-link {
+    display: inline-block;
+    margin-top: 1.5rem;
+    color: #2a7ae2;
+    text-decoration: none;
+}

--- a/web/src/main/resources/templates/author-detail.html
+++ b/web/src/main/resources/templates/author-detail.html
@@ -5,7 +5,7 @@
 
 <head>
   <title th:text="${author.name}">Author Name</title>
-  <link rel="stylesheet" th:href="@{/css/author-detail.css}"/>
+  <link rel="stylesheet" th:href="@{/author-detail.css}"/>
 </head>
 <body>
 <div layout:fragment="content">
@@ -13,7 +13,9 @@
 
 
     <img th:if="${author.authorImageUrl != null}"
-         th:src="${author.authorImageUrl}"
+         th:src="${author.authorImageUrl.startsWith('/uploads/authors')
+                 ? 'http://localhost:5000' + author.authorImageUrl
+                 : author.authorImageUrl}"
          alt="Author photo"/>
 
     <div class="author-info">

--- a/web/src/main/resources/templates/author-detail.html
+++ b/web/src/main/resources/templates/author-detail.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/public-layout.html}">
+
+<head>
+  <title th:text="${author.name}">Author Name</title>
+  <link rel="stylesheet" th:href="@{/css/author-detail.css}"/>
+</head>
+<body>
+<div layout:fragment="content">
+  <div class="author-detail">
+
+
+    <img th:if="${author.authorImageUrl != null}"
+         th:src="${author.authorImageUrl}"
+         alt="Author photo"/>
+
+    <div class="author-info">
+
+      <h1 th:text="${author.name}">Author Name</h1>
+
+
+      <p class="bio" th:text="${author.bio}">
+        Author biography goes here
+      </p>
+
+
+      <div class="author-books" th:if="${author.books != null and !author.books.isEmpty()}">
+        <h2>Books</h2>
+        <ul>
+
+          <li th:each="book : ${author.books}">
+            <a th:href="@{'/books/' + ${book.id}}"
+               th:text="${book.title}">Book Title</a>
+            <span class="book-price"
+                  th:if="${book.price != null}"
+                  th:text="' — $' + ${book.price}">$0.00</span>
+          </li>
+        </ul>
+      </div>
+
+
+      <a th:href="@{/}" class="back-link">Back to all books</a>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/web/src/main/resources/templates/book-detail.html
+++ b/web/src/main/resources/templates/book-detail.html
@@ -3,13 +3,15 @@
       layout:decorate="~{layout/public-layout.html}">
 <head>
     <title th:text="${book.title}">Book Title</title>
-    <link rel="stylesheet" th:href="@{/css/book-detail.css}"/>
+    <link rel="stylesheet" th:href="@{/book-detail.css}"/>
 </head>
 <body>
 <div layout:fragment="content">
     <div class="book-detail">
         <img th:if="${book.coverImageUrl != null}"
-             th:src="${book.coverImageUrl}"
+             th:src="${book.coverImageUrl.startsWith('/uploads/books')
+                     ? 'http://localhost:5000' + book.coverImageUrl
+                     : book.coverImageUrl}"
              alt="Book cover"/>
 
         <div class="book-info">

--- a/web/src/main/resources/templates/book-detail.html
+++ b/web/src/main/resources/templates/book-detail.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/public-layout.html}">
+<head>
+    <title th:text="${book.title}">Book Title</title>
+    <link rel="stylesheet" th:href="@{/css/book-detail.css}"/>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="book-detail">
+        <img th:if="${book.coverImageUrl != null}"
+             th:src="${book.coverImageUrl}"
+             alt="Book cover"/>
+
+        <div class="book-info">
+            <h1 th:text="${book.title}">Title</h1>
+            <p class="author">
+                by <a th:href="@{'/authors/' + ${book.authorId}}"
+                      th:text="${book.authorName}">Author Name</a>
+            </p>
+            <p class="genre" th:text="${book.genre}">Genre</p>
+            <p class="description" th:text="${book.description}">
+                Description text
+            </p>
+
+            <div class="pricing">
+                        <span class="price"
+                              th:text="'$' + ${book.price}">$0.00</span>
+            </div>
+
+            <p class="stock"
+               th:if="${book.quantity != null and book.quantity > 0}"
+               th:text="${book.quantity} + ' in stock'">In stock</p>
+            <p class="out-of-stock"
+               th:if="${book.quantity == null or book.quantity == 0}">
+                Out of stock
+            </p>
+
+            <a th:href="@{/}" class="back-link">Back to all books</a>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/web/src/main/resources/templates/books.html
+++ b/web/src/main/resources/templates/books.html
@@ -11,7 +11,7 @@
             <h1>Books</h1>
             <div>
                 <th:block th:each="book : ${books}">
-                    <div th:text="${book.title}"></div>
+                    <a th:href="@{'/books/' + ${book.id}}" th:text="${book.title}"></a>
                 </th:block>
             </div>
         </div>


### PR DESCRIPTION
#### Description
Added the author detail page at `/authors/:id`. Clicking an author name on the book detail page now takes you to a view showing the author's photo, name, bio, and a list of their books. Each book in the list links back to the book detail page.
#### Notes
- Created a new public-facing Feign client `IAuthorsClient.java` separate from the admin client
- Created a new `AuthorsPageController.java` to keep author routes organized
- Author's book list links back to the existing book detail pages
#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation update
- [ ]  Refactor
- [ ]  Hotfix
- [ ]  Security patch
- [ ]  UI/UX improvement
- [ ]  Dependency update
- [ ]  CI/CD update

---

#### **Screenshot or link to relevant section of the app if applicable**

<img width="1253" height="593" alt="image" src="https://github.com/user-attachments/assets/2a18bb75-9cb6-4ed0-bbdd-4c03c6782f7f" />


---

#### Checklist

- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  `main` has been merged into this branch
- [ x ]  The project builds and runs locally
- [ x ]  This change has been tested in development
- [ x ]  This change generates no new CodeQL alerts