### PR TITLE
Style books listing page

### DIFF
--- a/web/src/main/resources/static/books.css
+++ b/web/src/main/resources/static/books.css
@@ -1,0 +1,163 @@
+.page-title {
+    text-align: center;
+    margin: 2rem 0;
+    font-size: 1.8rem;
+    color: #2c3e6b;
+}
+
+
+.book-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 24px;
+    padding: 0 2rem 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+
+.book-card {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.book-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+}
+
+
+.book-cover {
+    width: 100%;
+    height: 280px;
+    object-fit: cover;
+    background: #e0e0e0;
+}
+
+
+.book-info {
+    padding: 12px 16px 8px;
+    flex: 1;
+}
+
+.book-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 4px;
+    line-height: 1.3;
+}
+
+.book-title a {
+    color: #2c3e6b;
+    text-decoration: none;
+}
+
+.book-title a:hover {
+    text-decoration: underline;
+}
+
+.book-author {
+    font-size: 0.85rem;
+    color: #2a7ae2;
+    text-decoration: none;
+    display: block;
+    margin-bottom: 2px;
+}
+
+.book-author:hover {
+    text-decoration: underline;
+}
+
+.book-genre {
+    font-size: 0.8rem;
+    color: #999;
+    font-style: italic;
+    margin: 0;
+}
+
+.book-actions {
+    padding: 4px 16px 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.book-price {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #2c3e6b;
+}
+
+.stock-badge {
+    font-size: 0.7rem;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.stock-badge.in-stock {
+    background: #e6f4ea;
+    color: #1e7e34;
+}
+
+.stock-badge.out-of-stock {
+    background: #fde8e8;
+    color: #c0392b;
+}
+
+.book-buttons {
+    padding: 8px 16px 16px;
+    display: flex;
+    gap: 8px;
+}
+
+.btn {
+    display: inline-block;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-align: center;
+    text-decoration: none;
+    transition: background 0.2s, opacity 0.2s;
+    flex: 1;
+}
+
+.btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.btn-details {
+    background: #2c3e6b;
+    color: #fff;
+}
+
+.btn-details:hover {
+    background: #1e2d52;
+}
+
+.btn-cart {
+    background: #27763d;
+    color: #fff;
+}
+
+.btn-cart:hover:not(:disabled) {
+    background: #1e5c30;
+}
+
+.empty-state {
+    text-align: center;
+    padding: 60px 20px;
+    color: #999;
+    font-size: 1.1rem;
+}

--- a/web/src/main/resources/templates/books.html
+++ b/web/src/main/resources/templates/books.html
@@ -8,12 +8,44 @@
     <body>
         <!-- start fragment here -->
         <div layout:fragment="content">
-            <h1>Books</h1>
-            <div>
-                <th:block th:each="book : ${books}">
-                    <a th:href="@{'/books/' + ${book.id}}" th:text="${book.title}"></a>
-                </th:block>
+            <h1 class="page-title">Books</h1>
+
+            <div class="book-grid">
+                <div class="book-card" th:each="book : ${books}">
+
+                    <a th:href="@{'/books/' + ${book.id}}">
+                        <img class="book-cover"
+                             th:src="${book.coverImageUrl != null ? book.coverImageUrl : '/images/placeholder.png'}"
+                             th:alt="${book.title}"/>
+                    </a>
+
+                    <div class="book-info">
+                        <h3 class="book-title">
+                            <a th:href="@{'/books/' + ${book.id}}" th:text="${book.title}">Title</a>
+                        </h3>
+                        <a class="book-author" th:href="@{'/authors/' + ${book.authorId}}" th:text="${book.authorName}">Author</a>
+                        <p class="book-genre" th:text="${book.genre}">Genre</p>
+                    </div>
+
+                    <div class="book-actions">
+                        <span class="book-price" th:text="'$' + ${#numbers.formatDecimal(book.price, 1, 2)}">$0.00</span>
+                        <span class="stock-badge in-stock" th:if="${book.quantity > 0}">In Stock</span>
+                        <span class="stock-badge out-of-stock" th:if="${book.quantity <= 0}">Out of Stock</span>
+                    </div>
+
+                    <div class="book-buttons">
+                        <a th:href="@{'/books/' + ${book.id}}" class="btn btn-details">Details</a>
+                        <button class="btn btn-cart" th:disabled="${book.quantity <= 0}">Add to Cart</button>
+                    </div>
+                </div>
             </div>
+
+            <div class="empty-state" th:if="${#lists.isEmpty(books)}">
+                <p>No books available yet. Check back soon!</p>
+            </div>
+
+
+
         </div>
     </body>
 </html>

--- a/web/src/main/resources/templates/books.html
+++ b/web/src/main/resources/templates/books.html
@@ -15,7 +15,9 @@
 
                     <a th:href="@{'/books/' + ${book.id}}">
                         <img class="book-cover"
-                             th:src="${book.coverImageUrl != null ? book.coverImageUrl : '/images/placeholder.png'}"
+                             th:src="${book.coverImageUrl.startsWith('/uploads/books')
+                                 ? 'http://localhost:5000' + book.coverImageUrl
+                                 : book.coverImageUrl}"
                              th:alt="${book.title}"/>
                     </a>
 

--- a/web/src/main/resources/templates/layout/public-layout.html
+++ b/web/src/main/resources/templates/layout/public-layout.html
@@ -19,7 +19,7 @@
             <a href="/account" id="accountLink" class="user" style="display: none;">My account</a>
         </div>
         <!-- start fragment here -->
-        <div class="put-fragment-here" style="width: 100%;" layout:fragment="content">
+        <div class="put-fragment-here" layout:fragment="content">
         </div>
     </body>
 


### PR DESCRIPTION
#### Description
Styled the books listing page at `/books` with a responsive card grid layout. Each book now displays its cover image, title, author, genre, price, and stock status.
#### Notes
- Book titles link to the book detail page
- Author names link to the author detail page
- "Add to Cart" button is disabled when a book is out of stock
- Grid auto-adjusts from 1 to 4 columns based on screen width
#### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation update
- [ ]  Refactor
- [ ]  Hotfix
- [ ]  Security patch
- [ x ]  UI/UX improvement
- [ ]  Dependency update
- [ ]  CI/CD update

---

#### **Screenshot or link to relevant section of the app if applicable**

<img width="2556" height="1319" alt="Screenshot 2026-03-16 200533" src="https://github.com/user-attachments/assets/70e9266b-6550-442b-810b-2b2ab546c38e" />


---

#### Checklist

- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  `main` has been merged into this branch
- [ x ]  The project builds and runs locally
- [ x ]  This change has been tested in development
- [ x ]  This change generates no new CodeQL alerts